### PR TITLE
Add initial Streamlit CRM application

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+__pycache__/
+*.pyc
+*.pyo
+*.sqlite3
+*.db
+.streamlit/secrets.toml
+data/seed/*.xlsx

--- a/.streamlit/config.toml
+++ b/.streamlit/config.toml
@@ -1,0 +1,5 @@
+[theme]
+primaryColor = "#F63366"
+backgroundColor = "#FFFFFF"
+secondaryBackgroundColor = "#F0F2F6"
+textColor = "#262730"

--- a/README.md
+++ b/README.md
@@ -1,2 +1,47 @@
-# codex
-Repo na skúšanie vecí s codexom
+# REMARK CRM
+
+Streamlit aplikácia pre správu leadov pre firmu REMARK Interier.
+
+## Spustenie
+
+```bash
+pip install -r requirements.txt
+streamlit run src/app.py
+```
+
+## Konfigurácia `secrets.toml`
+Všetky citlivé údaje sú mimo repozitára a ukladajú sa do `secrets.toml` v Streamlit Cloud.
+Príklad konfigurácie:
+
+```toml
+[db]
+connection = "sqlite:///data/remark_crm.db"  # alebo Postgres connection string
+
+[auth]
+allowed_emails = ["user@example.com"]
+
+[[auth.users]]
+email = "user@example.com"
+name = "User"
+password = "hashed_password"
+
+[auth.roles]
+"user@example.com" = "admin"
+
+[auth.cookie]
+name = "remark_crm"
+key = "some-secret-key"
+expiry_days = 1
+```
+
+- `allowed_emails` určuje, kto sa môže prihlásiť.
+- `auth.roles` definuje rolu používateľa (`admin` alebo `user`).
+- Export dát je dostupný iba pre rolu `admin`.
+
+## Stránky
+- **Leads** – prehľad a správa leadov.
+- **Summary** – štatistiky a grafy.
+- **Import/Export** – import z Excelu a export do CSV/XLSX.
+- **Nastavenia** – prehľad povolených e-mailov.
+
+Dátová schéma vychádza zo súboru `CRM_leads_REMARK_FIXED.xlsx` (nie je súčasťou repozitára; umiestnite ho do `data/seed/` podľa potreby).

--- a/data/seed/README.md
+++ b/data/seed/README.md
@@ -1,0 +1,1 @@
+This directory is intentionally left blank. Place `CRM_leads_REMARK_FIXED.xlsx` here locally for seeding the database; the file is not tracked in git.

--- a/pages/1_Leads.py
+++ b/pages/1_Leads.py
@@ -1,0 +1,12 @@
+import streamlit as st
+
+from src.ui.layout import init_page
+from src.auth import login
+from src.db import init_db
+from src.ui.table import leads_table
+
+init_page()
+init_db()
+authenticator, role = login()
+authenticator.logout("Odhlásiť", "sidebar")
+leads_table()

--- a/pages/2_Summary.py
+++ b/pages/2_Summary.py
@@ -1,0 +1,12 @@
+import streamlit as st
+
+from src.ui.layout import init_page
+from src.auth import login
+from src.db import init_db
+from src.ui.summary import summary_view
+
+init_page()
+init_db()
+authenticator, role = login()
+authenticator.logout("Odhlásiť", "sidebar")
+summary_view()

--- a/pages/3_Import_Export.py
+++ b/pages/3_Import_Export.py
@@ -1,0 +1,33 @@
+import streamlit as st
+import pandas as pd
+
+from src.ui.layout import init_page
+from src.auth import login
+from src.db import init_db, get_session
+from src.import_export import import_from_excel, export_dataframe
+from src.repository import LeadRepository
+
+init_page()
+init_db()
+authenticator, role = login()
+authenticator.logout("Odhlásiť", "sidebar")
+
+st.header("Import / Export")
+
+uploaded = st.file_uploader("Excel súbor", type=["xlsx"])
+if uploaded and st.button("Importovať"):
+    count = import_from_excel(uploaded)
+    st.success(f"Importovaných {count} záznamov")
+
+session = get_session()
+repo = LeadRepository(session)
+leads = repo.all()
+df = pd.DataFrame([l.__dict__ for l in leads]).drop(columns=["_sa_instance_state"], errors="ignore")
+
+if role == "admin" and not df.empty:
+    fmt = st.selectbox("Formát", ["csv", "xlsx"])
+    data = export_dataframe(df, fmt)
+    mime = "text/csv" if fmt == "csv" else "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+    st.download_button("Export", data=data, file_name=f"leads.{fmt}", mime=mime)
+else:
+    st.info("Export je dostupný len administrátorom")

--- a/pages/4_Nastavenia.py
+++ b/pages/4_Nastavenia.py
@@ -1,0 +1,14 @@
+import streamlit as st
+
+from src.ui.layout import init_page
+from src.auth import login
+from src.db import init_db
+
+init_page()
+init_db()
+authenticator, role = login()
+authenticator.logout("Odhlásiť", "sidebar")
+
+st.header("Nastavenia")
+st.write("Zoznam povolených e-mailov:")
+st.write(st.secrets.get("auth", {}).get("allowed_emails", []))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,10 @@
+streamlit
+pandas
+numpy
+openpyxl
+sqlalchemy
+plotly
+python-dateutil
+xlsxwriter
+streamlit-authenticator
+streamlit-aggrid

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,0 +1,1 @@
+"""REMARK CRM package."""

--- a/src/app.py
+++ b/src/app.py
@@ -1,0 +1,20 @@
+"""Main entry for REMARK CRM."""
+from __future__ import annotations
+
+import streamlit as st
+
+from .db import init_db
+from .ui.layout import init_page
+from .auth import login
+
+
+def main() -> None:
+    init_page()
+    init_db()
+    authenticator, role = login()
+    authenticator.logout("Odhlásiť", "sidebar")
+    st.write("Vitajte v REMARK CRM. Použite menu vľavo na navigáciu.")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/auth.py
+++ b/src/auth.py
@@ -1,0 +1,39 @@
+"""Authentication helpers."""
+from __future__ import annotations
+
+import streamlit as st
+import streamlit_authenticator as stauth
+
+
+def login() -> tuple[stauth.Authenticate, str]:
+    """Authenticate user and return authenticator and role."""
+    auth_conf = st.secrets.get("auth", {})
+    credentials = {"usernames": {}}
+    for user in auth_conf.get("users", []):
+        credentials["usernames"][user["email"]] = {
+            "email": user["email"],
+            "name": user.get("name", user["email"]),
+            "password": user["password"],
+        }
+
+    authenticator = stauth.Authenticate(
+        credentials,
+        auth_conf.get("cookie", {}).get("name", "crm"),
+        auth_conf.get("cookie", {}).get("key", "key"),
+        auth_conf.get("cookie", {}).get("expiry_days", 1),
+    )
+
+    name, auth_status, username = authenticator.login("Login", "main")
+
+    if not auth_status:
+        st.warning("Please enter your credentials")
+        st.stop()
+
+    allowed = username in auth_conf.get("allowed_emails", [])
+    if not allowed:
+        st.error("Access denied")
+        st.stop()
+
+    role = auth_conf.get("roles", {}).get(username, "user")
+    st.session_state["role"] = role
+    return authenticator, role

--- a/src/db.py
+++ b/src/db.py
@@ -1,0 +1,37 @@
+"""Database setup and utilities."""
+from __future__ import annotations
+
+import streamlit as st
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker, declarative_base
+
+Base = declarative_base()
+_engine = None
+_SessionLocal = None
+
+
+def get_engine():
+    """Return a SQLAlchemy engine using the connection in ``st.secrets``."""
+    global _engine, _SessionLocal
+    if _engine is None:
+        db_url = st.secrets.get("db", {}).get("connection", "sqlite:///data/remark_crm.db")
+        if db_url.startswith("sqlite"):
+            _engine = create_engine(db_url, connect_args={"check_same_thread": False})
+        else:
+            _engine = create_engine(db_url)
+        _SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=_engine)
+    return _engine
+
+
+def get_session():
+    """Return a new SQLAlchemy session."""
+    global _SessionLocal
+    if _SessionLocal is None:
+        get_engine()
+    return _SessionLocal()
+
+
+def init_db():
+    """Create database tables."""
+    engine = get_engine()
+    Base.metadata.create_all(bind=engine)

--- a/src/import_export.py
+++ b/src/import_export.py
@@ -1,0 +1,40 @@
+"""Import and export utilities."""
+from __future__ import annotations
+
+import io
+from pathlib import Path
+from typing import Iterable
+
+import pandas as pd
+import streamlit as st
+
+from .db import get_session
+from .repository import LeadRepository
+
+
+def import_from_excel(path: str | Path) -> int:
+    """Import leads from an Excel file into the database.
+
+    Returns the number of imported rows.
+    """
+
+    df = pd.read_excel(path, sheet_name="Leads")
+    df.columns = [c.strip().lower() for c in df.columns]
+    session = get_session()
+    repo = LeadRepository(session)
+    count = 0
+    for _, row in df.iterrows():
+        data = {k: (v.to_pydatetime().date() if hasattr(v, "to_pydatetime") else v) for k, v in row.items() if pd.notna(v)}
+        repo.add(data)
+        count += 1
+    return count
+
+
+def export_dataframe(df: pd.DataFrame, fmt: str = "csv") -> bytes:
+    """Return dataframe serialized to the given format."""
+    buf = io.BytesIO()
+    if fmt == "csv":
+        df.to_csv(buf, index=False)
+    else:
+        df.to_excel(buf, index=False)
+    return buf.getvalue()

--- a/src/models.py
+++ b/src/models.py
@@ -1,0 +1,32 @@
+"""Database models."""
+from __future__ import annotations
+
+from sqlalchemy import Column, Integer, String, Date, Float
+
+from .db import Base
+
+
+class Lead(Base):
+    """CRM lead model."""
+
+    __tablename__ = "leads"
+
+    id = Column(Integer, primary_key=True, index=True)
+    meno_zakaznika = Column(String, nullable=False)
+    telefon = Column(String)
+    email = Column(String)
+    mesto = Column(String)
+    typ_dopytu = Column(String)
+    datum_povodneho_kontaktu = Column(Date)
+    stav_projektu = Column(String)
+    konkurencia = Column(String)
+    cena_konkurencie = Column(Float)
+    nasa_ponuka_orientacna = Column(Float)
+    reakcia_zakaznika = Column(String)
+    dalsi_krok = Column(String)
+    datum_dalsieho_kroku = Column(Date)
+    priorita = Column(String)
+    stav_leadu = Column(String)
+    orientacna_cena = Column(Float)
+    datum_realizacie = Column(Date)
+    poznamky = Column(String)

--- a/src/repository.py
+++ b/src/repository.py
@@ -1,0 +1,43 @@
+"""Repository layer for database operations."""
+from __future__ import annotations
+
+from typing import Iterable, List
+
+from sqlalchemy.orm import Session
+
+from . import models
+
+
+class LeadRepository:
+    """CRUD operations for :class:`~models.Lead`."""
+
+    def __init__(self, session: Session):
+        self.session = session
+
+    def all(self) -> List[models.Lead]:
+        return self.session.query(models.Lead).all()
+
+    def get(self, lead_id: int) -> models.Lead | None:
+        return self.session.get(models.Lead, lead_id)
+
+    def add(self, data: dict) -> models.Lead:
+        lead = models.Lead(**data)
+        self.session.add(lead)
+        self.session.commit()
+        self.session.refresh(lead)
+        return lead
+
+    def update(self, lead_id: int, data: dict) -> models.Lead:
+        lead = self.get(lead_id)
+        if lead is None:
+            raise ValueError("Lead not found")
+        for key, value in data.items():
+            setattr(lead, key, value)
+        self.session.commit()
+        return lead
+
+    def delete(self, lead_id: int) -> None:
+        lead = self.get(lead_id)
+        if lead:
+            self.session.delete(lead)
+            self.session.commit()

--- a/src/ui/alerts.py
+++ b/src/ui/alerts.py
@@ -1,0 +1,19 @@
+"""Alert utilities."""
+from __future__ import annotations
+
+from datetime import date, timedelta
+
+import pandas as pd
+import streamlit as st
+
+
+def alerts_box(df: pd.DataFrame) -> None:
+    if df.empty or "datum_dalsieho_kroku" not in df.columns:
+        return
+    today = pd.to_datetime(date.today())
+    upcoming = df.dropna(subset=["datum_dalsieho_kroku"])
+    upcoming["datum_dalsieho_kroku"] = pd.to_datetime(upcoming["datum_dalsieho_kroku"])
+    overdue = upcoming[upcoming["datum_dalsieho_kroku"] < today]
+    today_df = upcoming[upcoming["datum_dalsieho_kroku"] == today]
+    next_week = upcoming[(upcoming["datum_dalsieho_kroku"] > today) & (upcoming["datum_dalsieho_kroku"] <= today + timedelta(days=7))]
+    st.info(f"Po termíne: {len(overdue)} | Dnes: {len(today_df)} | 7 dní: {len(next_week)}")

--- a/src/ui/detail.py
+++ b/src/ui/detail.py
@@ -1,0 +1,23 @@
+"""Lead detail view."""
+from __future__ import annotations
+
+import pandas as pd
+import streamlit as st
+
+from ..db import get_session
+from ..repository import LeadRepository
+
+
+def render_detail(lead_id: int) -> None:
+    session = get_session()
+    repo = LeadRepository(session)
+    lead = repo.get(lead_id)
+    if lead is None:
+        st.error("Lead nenájdený")
+        return
+    data = {c.name: getattr(lead, c.name) for c in lead.__table__.columns}
+    df = pd.DataFrame([data])
+    edited = st.data_editor(df, num_rows=1)
+    if st.button("Uložiť"):
+        repo.update(lead_id, edited.iloc[0].to_dict())
+        st.success("Uložené")

--- a/src/ui/forms.py
+++ b/src/ui/forms.py
@@ -1,0 +1,55 @@
+"""Forms used in the application."""
+from __future__ import annotations
+
+from datetime import date
+
+import streamlit as st
+
+from ..repository import LeadRepository
+
+
+def new_lead_form(repo: LeadRepository) -> None:
+    """Form for creating a new lead."""
+    with st.form("new-lead"):
+        meno = st.text_input("Meno zákazníka")
+        telefon = st.text_input("Telefón")
+        email = st.text_input("Email")
+        mesto = st.text_input("Mesto")
+        typ = st.text_input("Typ dopytu")
+        datum_kontaktu = st.date_input("Dátum pôvodného kontaktu", value=date.today())
+        stav_projektu = st.text_input("Stav projektu")
+        konkurencia = st.text_input("Konkurencia")
+        cena_konkurencie = st.number_input("Cena konkurencie", min_value=0.0, step=100.0)
+        nasa_ponuka = st.number_input("Naša ponuka orientačná", min_value=0.0, step=100.0)
+        reakcia = st.text_input("Reakcia zákazníka")
+        dalsi_krok = st.text_input("Ďalší krok")
+        datum_kroku = st.date_input("Dátum ďalšieho kroku")
+        priorita = st.selectbox("Priorita", ["Vysoká", "Stredná", "Nízka"])
+        stav_leadu = st.selectbox("Stav leadu", ["Open", "Cold", "Converted", "Lost"])
+        orientacna_cena = st.number_input("Orientačná cena", min_value=0.0, step=100.0)
+        datum_realizacie = st.date_input("Dátum realizácie", value=None)
+        poznamky = st.text_area("Poznámky")
+        submitted = st.form_submit_button("Uložiť")
+    if submitted:
+        repo.add({
+            "meno_zakaznika": meno,
+            "telefon": telefon,
+            "email": email,
+            "mesto": mesto,
+            "typ_dopytu": typ,
+            "datum_povodneho_kontaktu": datum_kontaktu,
+            "stav_projektu": stav_projektu,
+            "konkurencia": konkurencia,
+            "cena_konkurencie": cena_konkurencie,
+            "nasa_ponuka_orientacna": nasa_ponuka,
+            "reakcia_zakaznika": reakcia,
+            "dalsi_krok": dalsi_krok,
+            "datum_dalsieho_kroku": datum_kroku,
+            "priorita": priorita,
+            "stav_leadu": stav_leadu,
+            "orientacna_cena": orientacna_cena,
+            "datum_realizacie": datum_realizacie,
+            "poznamky": poznamky,
+        })
+        st.success("Lead pridaný")
+        st.experimental_rerun()

--- a/src/ui/layout.py
+++ b/src/ui/layout.py
@@ -1,0 +1,8 @@
+"""Layout helpers."""
+from __future__ import annotations
+
+import streamlit as st
+
+
+def init_page():
+    st.set_page_config(page_title="REMARK CRM", layout="wide")

--- a/src/ui/summary.py
+++ b/src/ui/summary.py
@@ -1,0 +1,33 @@
+"""Summary and statistics page."""
+from __future__ import annotations
+
+import pandas as pd
+import plotly.express as px
+import streamlit as st
+
+from ..db import get_session
+from ..repository import LeadRepository
+
+
+def summary_view() -> None:
+    session = get_session()
+    repo = LeadRepository(session)
+    leads = repo.all()
+    df = pd.DataFrame([l.__dict__ for l in leads]).drop(columns=["_sa_instance_state"], errors="ignore")
+    if df.empty:
+        st.info("Žiadne dáta")
+        return
+
+    st.subheader("Počty leadov podľa stavu")
+    fig = px.bar(df.groupby("stav_leadu").size().reset_index(name="count"), x="stav_leadu", y="count")
+    st.plotly_chart(fig, use_container_width=True)
+
+    st.subheader("Počty podľa priority")
+    fig = px.pie(df, names="priorita")
+    st.plotly_chart(fig, use_container_width=True)
+
+    st.subheader("Trend nových leadov")
+    df["datum_povodneho_kontaktu"] = pd.to_datetime(df["datum_povodneho_kontaktu"])
+    trend = df.groupby(pd.Grouper(key="datum_povodneho_kontaktu", freq="M")).size().reset_index(name="count")
+    fig = px.line(trend, x="datum_povodneho_kontaktu", y="count")
+    st.plotly_chart(fig, use_container_width=True)

--- a/src/ui/table.py
+++ b/src/ui/table.py
@@ -1,0 +1,98 @@
+"""Leads table view."""
+from __future__ import annotations
+
+import pandas as pd
+import streamlit as st
+
+from ..db import get_session
+from ..repository import LeadRepository
+from .forms import new_lead_form
+from .detail import render_detail
+from .alerts import alerts_box
+
+
+STATUS_COLORS = {
+    "Open": "#fff3cd",
+    "Cold": "#dceef9",
+    "Converted": "#d4edda",
+    "Lost": "#f8d7da",
+}
+PRIORITY_COLORS = {
+    "Vysoká": "#f8d7da",
+    "Stredná": "#ffe5b4",
+    "Nízka": "#dceef9",
+}
+
+
+def _style_row(row: pd.Series) -> list[str]:
+    color = STATUS_COLORS.get(row.get("stav_leadu"), "")
+    return [f"background-color: {color}"] * len(row)
+
+
+def leads_table() -> None:
+    session = get_session()
+    repo = LeadRepository(session)
+    leads = repo.all()
+    if not leads:
+        st.info("Žiadne leady. Importujte alebo pridajte nový.")
+    df = pd.DataFrame([l.__dict__ for l in leads]).drop(columns=["_sa_instance_state"], errors="ignore")
+
+    alerts_box(df)
+
+    with st.expander("Filtre", expanded=False):
+        col1, col2, col3 = st.columns(3)
+        with col1:
+            status_filter = st.multiselect("Stav leadu", sorted(df["stav_leadu"].dropna().unique()))
+        with col2:
+            priority_filter = st.multiselect("Priorita", sorted(df["priorita"].dropna().unique()))
+        with col3:
+            typ_filter = st.multiselect("Typ dopytu", sorted(df["typ_dopytu"].dropna().unique()))
+        search = st.text_input("Fulltext")
+
+    if status_filter:
+        df = df[df["stav_leadu"].isin(status_filter)]
+    if priority_filter:
+        df = df[df["priorita"].isin(priority_filter)]
+    if typ_filter:
+        df = df[df["typ_dopytu"].isin(typ_filter)]
+    if search:
+        df = df[df.apply(lambda r: r.astype(str).str.contains(search, case=False, na=False).any(), axis=1)]
+
+    editable_cols = [
+        "stav_leadu",
+        "priorita",
+        "stav_projektu",
+        "dalsi_krok",
+        "datum_dalsieho_kroku",
+        "poznamky",
+        "nasa_ponuka_orientacna",
+    ]
+
+    edited = st.data_editor(
+        df.style.apply(_style_row, axis=1),
+        use_container_width=True,
+        disabled=[c for c in df.columns if c not in editable_cols],
+    )
+
+    if not edited.equals(df):
+        for _, row in edited.iterrows():
+            orig = df[df["id"] == row["id"]].iloc[0]
+            changed = {
+                col: row[col]
+                for col in editable_cols
+                if str(row[col]) != str(orig[col])
+            }
+            if changed:
+                repo.update(int(row["id"]), changed)
+        st.experimental_rerun()
+
+    st.divider()
+    st.subheader("Detail")
+    if not df.empty:
+        selected_id = st.selectbox("Vyber lead", df["id"].tolist())
+        if selected_id:
+            render_detail(int(selected_id))
+
+    st.divider()
+    if st.button("Nový lead"):
+        new_lead_form(repo)


### PR DESCRIPTION
## Summary
- scaffold Streamlit-based CRM with SQLAlchemy models and repository layer
- implement authentication, import/export, summary statistics and alerts
- add sample Excel seed data and documentation for secrets configuration
- drop committed Excel seed file and document placing it locally

## Testing
- `python -m py_compile $(find . -name '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68ab59fc0f208324ad2fea1446cfbd6a