### PR TITLE
fix: use absolute imports in app

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -3,9 +3,9 @@ from __future__ import annotations
 
 import streamlit as st
 
-from .db import init_db
-from .ui.layout import init_page
-from .auth import login
+from src.db import init_db
+from src.ui.layout import init_page
+from src.auth import login
 
 
 def main() -> None:


### PR DESCRIPTION
## Summary
- fix ImportError by using absolute package imports in main app

## Testing
- `pytest -q`
- `python -m py_compile src/app.py`


------
https://chatgpt.com/codex/tasks/task_e_68abf43fcd9c8324b2bb8c27632d2f3b