### PR TITLE
Ensure project root on PYTHONPATH

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -1,7 +1,15 @@
 """Main entry for REMARK CRM."""
 from __future__ import annotations
 
+import sys
+from pathlib import Path
+
 import streamlit as st
+
+# Ensure project root is on the Python path when running as a script
+ROOT_DIR = Path(__file__).resolve().parent.parent
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
 
 from src.db import init_db
 from src.ui.layout import init_page


### PR DESCRIPTION
## Summary
- add root directory to `sys.path` so `from src` imports work when running via `streamlit run src/app.py`

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python src/app.py` *(fails: StreamlitSecretNotFoundError: No secrets found)*

------
https://chatgpt.com/codex/tasks/task_e_68ac07aa20f48324b5d90b8fb00801b0