### PR TITLE
Fix streamlit-authenticator login API usage

### DIFF
--- a/src/auth.py
+++ b/src/auth.py
@@ -23,7 +23,7 @@ def login() -> tuple[stauth.Authenticate, str]:
         auth_conf.get("cookie", {}).get("expiry_days", 1),
     )
 
-    name, auth_status, username = authenticator.login("Login", "main")
+    name, auth_status, username = authenticator.login(location="main", key="Login")
 
     if not auth_status:
         st.warning("Please enter your credentials")


### PR DESCRIPTION
## Summary
- adjust login call to specify location keyword

## Testing
- `python -m py_compile src/auth.py`
- `python -m py_compile src/app.py`


------
https://chatgpt.com/codex/tasks/task_e_68ac086e9fb8832482e58cdd8bc8bc5e